### PR TITLE
feat(spectator): handler for metrics

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,7 @@ module github.com/Netflix/spectator-go
 
 go 1.12
 
-require github.com/pkg/errors v0.8.1
+require (
+	github.com/pkg/errors v0.8.1
+	github.com/stretchr/testify v1.4.0
+)

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,12 @@
+github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
+github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
+gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/http_handler.go
+++ b/http_handler.go
@@ -1,0 +1,42 @@
+package spectator
+
+import (
+	"encoding/json"
+	"net/http"
+)
+
+type Tag struct {
+	Key   string `json:"key"`
+	Value string `json:"value"`
+}
+
+type Value struct {
+	V int   `json:"v"`
+	T int64 `json:"t"`
+}
+
+type TopValue struct {
+	Tags   []Tag    `json:"tags"`
+	Values []*Value `json:"values"`
+}
+
+type Metric struct {
+	Kind   string     `json:"kind"`
+	Values []TopValue `json:"values"`
+}
+
+func HttpHandler(registry *Registry) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		// w.Write([]byte("whatever"))
+
+		// var payload []interface{}
+		// strings := r.buildStringTable(&payload, measurements)
+		// for _, m := range measurements {
+		// 	r.appendMeasurement(&payload, strings, m)
+		// }
+		payload := registry.GetExport()
+		b, _ := json.Marshal(payload)
+		w.Write(b)
+	}
+}

--- a/http_handler.go
+++ b/http_handler.go
@@ -28,13 +28,6 @@ type Metric struct {
 func HttpHandler(registry *Registry) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
-		// w.Write([]byte("whatever"))
-
-		// var payload []interface{}
-		// strings := r.buildStringTable(&payload, measurements)
-		// for _, m := range measurements {
-		// 	r.appendMeasurement(&payload, strings, m)
-		// }
 		payload := registry.GetExport()
 		b, _ := json.Marshal(payload)
 		w.Write(b)

--- a/registry.go
+++ b/registry.go
@@ -6,6 +6,7 @@ import (
 	"io/ioutil"
 	"math"
 	"path/filepath"
+	"reflect"
 	"sort"
 	"sync"
 	"time"
@@ -34,6 +35,7 @@ type Registry struct {
 	mutex   *sync.Mutex
 	http    *HttpClient
 	quit    chan struct{}
+	export  map[string]Metric
 }
 
 func NewRegistryConfiguredBy(filePath string) (*Registry, error) {
@@ -64,7 +66,7 @@ func NewRegistry(config *Config) *Registry {
 	}
 
 	r := &Registry{&SystemClock{}, config, map[string]Meter{}, false,
-		&sync.Mutex{}, nil, make(chan struct{})}
+		&sync.Mutex{}, nil, make(chan struct{}), map[string]Metric{}}
 	r.http = NewHttpClient(r, r.config.Timeout)
 	return r
 }
@@ -88,9 +90,21 @@ func (r *Registry) SetLogger(logger Logger) {
 	r.config.Log = logger
 }
 
+func (r *Registry) GetExport() map[string]Metric {
+	r.mutex.Lock()
+	defer r.mutex.Unlock()
+	return r.export
+}
+
+func (r *Registry) SetExport(e map[string]Metric) {
+	r.mutex.Lock()
+	defer r.mutex.Unlock()
+	r.export = e
+}
+
 func (r *Registry) Start() error {
-	if r.config == nil || r.config.Uri == "" {
-		err := fmt.Sprintf("registry config has no uri. Ignoring Start request")
+	if r.config == nil {
+		err := fmt.Sprintf("registry config does not exist. Ignoring Start request")
 		r.config.Log.Infof(err)
 		return fmt.Errorf(err)
 	}
@@ -166,22 +180,30 @@ func (r *Registry) sendBatch(measurements []Measurement) {
 }
 
 func (r *Registry) publish() {
-	if len(r.config.Uri) == 0 {
-		return
-	}
-
-	measurements := r.Measurements()
-	r.config.Log.Debugf("Got %d measurements", len(measurements))
-	if !r.config.IsEnabled() {
-		return
-	}
-
-	for i := 0; i < len(measurements); i += r.config.BatchSize {
-		end := i + r.config.BatchSize
-		if end > len(measurements) {
-			end = len(measurements)
+	if r.config.Uri == "" {
+		// internal publish
+		// 	We merge new metrics into the Export as sample instances are not the same for all metrics
+		new := Convert(r)
+		export := r.GetExport()
+		for k, v := range new {
+			export[k] = v
 		}
-		r.sendBatch(measurements[i:end])
+		r.SetExport(export)
+	} else {
+		// external publish
+		measurements := r.Measurements()
+		r.config.Log.Debugf("Got %d measurements", len(measurements))
+		if !r.config.IsEnabled() {
+			return
+		}
+
+		for i := 0; i < len(measurements); i += r.config.BatchSize {
+			end := i + r.config.BatchSize
+			if end > len(measurements) {
+				end = len(measurements)
+			}
+			r.sendBatch(measurements[i:end])
+		}
 	}
 }
 
@@ -355,4 +377,47 @@ func (r *Registry) DistributionSummaryWithId(id *Id) *DistributionSummary {
 
 func (r *Registry) DistributionSummary(name string, tags map[string]string) *DistributionSummary {
 	return r.DistributionSummaryWithId(NewId(name, tags))
+}
+
+func Convert(r *Registry) map[string]Metric {
+	// Take a Registry, convert and return all internal measurements in a format for export
+
+	data := map[string]Metric{}
+	ctags := r.config.CommonTags
+
+	for _, meter := range r.meters {
+		kind := reflect.TypeOf(meter).Elem().Name()
+
+		for _, measurement := range meter.Measure() {
+			if shouldSendMeasurement(measurement) {
+				name := measurement.Id().Name()
+				value := int(measurement.Value())
+				ts := time.Now().UnixNano() / int64(time.Millisecond)
+				tags := measurement.Id().Tags()
+
+				metric := Metric{
+					Kind:   kind,
+					Values: []TopValue{},
+				}
+				topval := TopValue{
+					Tags: []Tag{},
+					Values: []*Value{
+						&Value{V: value, T: ts},
+					},
+				}
+
+				for k, v := range tags {
+					topval.Tags = append(topval.Tags, Tag{Key: k, Value: v})
+				}
+				for k, v := range ctags {
+					topval.Tags = append(topval.Tags, Tag{Key: k, Value: v})
+				}
+				metric.Values = append(metric.Values, topval)
+
+				data[name] = metric
+			}
+		}
+	}
+
+	return data
 }


### PR DESCRIPTION
## High Level
This extension of `spectator-go` makes it compatible to use as a metrics instrumenting library for our go applications in Spinnaker.

## Jira link
https://armory.atlassian.net/browse/ES-38

## Changelog

- Added new function `Convert` in registry.go that can be called by `publish` to transform metrics into the required format for sending via our handler
- Extended `Registry` with a property `Export` which keeps a cache of metrics to send
- Added tests for `Convert`
- Added new file `http_handler` to contain both the function to return the handler for metrics and define the structs used to form the exported metrics